### PR TITLE
fix: honor --no-gitignore flag for git filtering

### DIFF
--- a/rstring/cli.py
+++ b/rstring/cli.py
@@ -140,11 +140,12 @@ For frequently used patterns, create shell aliases:
 
         file_list = run_rsync(rsync_args)
 
-        # Apply git filtering if in a git repository
-        try:
-            file_list = filter_ignored_files(target_dir, file_list)
-        except Exception as e:
-            logger.warning(f"Git filtering failed: {e}")
+        # Apply git filtering if in a git repository and gitignore is enabled
+        if args.use_gitignore:
+            try:
+                file_list = filter_ignored_files(target_dir, file_list)
+            except Exception as e:
+                logger.warning(f"Git filtering failed: {e}")
 
         result = gather_code(file_list, args.preview_length, args.include_dirs)
 


### PR DESCRIPTION
- Git filtering was being applied regardless of --no-gitignore flag
- Now git filtering only occurs when args.use_gitignore is True
- Add regression tests to prevent future bugs:
  - test_no_gitignore_flag_skips_git_filtering()
  - test_default_behavior_applies_git_filtering()

Fixes issue where rstring would return 0 files in git-ignored directories even when --no-gitignore was specified.